### PR TITLE
Fixed NRE when DocumentGenerationServiceUri is null

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,2 +1,5 @@
+1.0.3
+* Fixed issue with NullReferenceException, when `options.DocumentGenerationServiceUri` is null
+
 0.1.0
 * Initial version

--- a/src/Kmd.Logic.DocumentGeneration.Client/LogicHttpClientProvider.cs
+++ b/src/Kmd.Logic.DocumentGeneration.Client/LogicHttpClientProvider.cs
@@ -55,7 +55,7 @@ namespace Kmd.Logic.DocumentGeneration.Client
 
                 this._internalClient = new InternalClient(new TokenCredentials(tokenProvider))
                 {
-                    BaseUri = this._options.DocumentGenerationServiceUri,
+                    BaseUri = this._options.DocumentGenerationServiceUri ?? new Uri("https://gateway.kmdlogic.io/document-generation/v2"),
                 };
 
                 return this._internalClient;


### PR DESCRIPTION
This PR addresses issue with `NullReferenceException` in case when consumer by set `DocumentGenerationServiceUri` to null.